### PR TITLE
Fixing crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Remove Third-party IntelliJ Plugin Verifier GitHub Action
 
 ### Fixed
+- Handling exceptions in 3D preview
 - GitHub Actions – cache Gradle dependencies and wrapper separately
 - `pluginName` variable name collision with `intellij` closure getter in Gradle configuration
 - Using correct encoding of ellipsis character when initializing 3D preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Cache downloaded IDEs used by Plugin Verifier for the verification
 
 ### Changed
+- Set default editor layout to text only
 - Update platform version to `2020.1`
 - GitHub Actions:
   - Simplify and optimize GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Handling exceptions in 3D preview
+- Trying to load different GL profiles (#38)
 - GitHub Actions – cache Gradle dependencies and wrapper separately
 - `pluginName` variable name collision with `intellij` closure getter in Gradle configuration
 - Using correct encoding of ellipsis character when initializing 3D preview

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjSplitEditor.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjSplitEditor.kt
@@ -59,7 +59,7 @@ class ObjSplitEditor(
 
     private val _component: JComponent by lazy { createComponent() }
 
-    var splitEditorLayout: SplitEditorLayout = SplitEditorLayout.SPLIT
+    var splitEditorLayout: SplitEditorLayout = SplitEditorLayout.TEXT
         private set
 
     init {

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ui/GLPanelWrapper.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ui/GLPanelWrapper.kt
@@ -23,6 +23,9 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.util.Disposer
 import com.jetbrains.rd.util.AtomicReference
 import com.jetbrains.rd.util.string.printToString
+import com.jogamp.opengl.GLCapabilities
+import com.jogamp.opengl.GLException
+import com.jogamp.opengl.GLProfile
 import com.jogamp.opengl.awt.GLJPanel
 import com.jogamp.opengl.math.FloatUtil
 import com.jogamp.opengl.util.FPSAnimator
@@ -84,7 +87,7 @@ class GLPanelWrapper : JPanel(BorderLayout()), Disposable {
 
     private fun attachJPanel() {
         try {
-            val canvas = GLJPanel()
+            val canvas = GLJPanel(getGLCapabilities())
             val animator = FPSAnimator(canvas, DEFAULT_FPS_LIMIT)
 
             presenter = GL2Presenter(animator, ::showError)
@@ -105,6 +108,24 @@ class GLPanelWrapper : JPanel(BorderLayout()), Disposable {
         } catch (expected: Throwable) {
             showError(expected)
         }
+    }
+
+    private fun getGLCapabilities(): GLCapabilities {
+        val supportedProfiles = listOf(
+            GLProfile.GL2ES1,
+            GLProfile.GLES1,
+            GLProfile.GL3bc,
+            GLProfile.GL4bc,
+            null,
+        )
+        for (profileName in supportedProfiles) {
+            try {
+                val profile = GLProfile.get(profileName)
+                return GLCapabilities(profile)
+            } catch (ignored: GLException) {
+            }
+        }
+        throw UnsupportedOperationException("Could not find any supported GL profile")
     }
 
     private fun showError(exception: Throwable) {

--- a/src/main/resources/messages/WavefrontObjBundle.properties
+++ b/src/main/resources/messages/WavefrontObjBundle.properties
@@ -28,6 +28,7 @@ fileTypes.obj.structure.presentation.error.unknownElement=Unknown element
 
 editor.fileTypes.obj.preview.name=3D preview
 editor.fileTypes.obj.preview.placeholder=Initializing 3D preview\u2026
+editor.fileTypes.obj.preview.error=3D preview error:
 editor.fileTypes.obj.split.name=Wavefront OBJ editor
 
 group.ObjSplitEditor.Toolbar.text=OBJ File Editor Actions


### PR DESCRIPTION
Changes:
* Handling exceptions in 3D preview
* Trying out different GL profiles before throwing an exception
* By default, editor layout set to text only, to prevent instant crashes