### PR TITLE
Add support for displacement textures in 3D preview (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@
 # Wavefront OBJ IntelliJ Plugin Changelog
 
 ## [Unreleased]
+### Added
+- Support for displacement textures in 3D preview
+- Cropping textures toggle action in 3D preview
+- Setting for cropping textures
+- Setting for displacement quality
+
 ### Changed
 - Group 3D preview editor color settings
+- Reorganise plugin settings
 - Use `gradle-grammarkit-plugin` to generate parsers and lexers
 - Remove reference to the `jcenter()` from Gradle configuration file
 - Upgrade Gradle Wrapper to `7.1`

--- a/src/main/java/icons/WavefrontObjIcons.java
+++ b/src/main/java/icons/WavefrontObjIcons.java
@@ -33,6 +33,9 @@ public class WavefrontObjIcons {
     public static final Icon MATERIAL_SHADING_ACTION = getIcon("/icons/editor_actions/materialShading.svg");
 
     @NotNull
+    public static final Icon TOGGLE_CROP_TEXTURES_ACTION = getIcon("/icons/editor_actions/cropTextures.svg");
+
+    @NotNull
     public static final Icon TOGGLE_AXES_ACTION = getIcon("/icons/editor_actions/axes.svg");
 
     @NotNull

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjPreviewComponent.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjPreviewComponent.kt
@@ -101,6 +101,13 @@ class ObjPreviewComponent(
             myLeftActionToolbar.updateActionsImmediately()
         }
 
+    var isCroppingTextures: Boolean = ObjPreviewSettingsState.DEFAULT_CROP_TEXTURES
+        set(value) {
+            field = value
+            updateScene()
+            myLeftActionToolbar.updateActionsImmediately()
+        }
+
     var upVector: UpVector = UpVector.DEFAULT
         set(value) {
             field = value
@@ -212,6 +219,7 @@ class ObjPreviewComponent(
             if (::myScene.isInitialized) {
                 myScene.cameraModel = cameraModel
                 myScene.shadingMethod = shadingMethod
+                myScene.cropTextures = isCroppingTextures
                 myScene.showAxes = isShowingAxes
                 myScene.showGrid = isShowingGrid
                 myScene.config = previewSceneConfig
@@ -223,6 +231,10 @@ class ObjPreviewComponent(
         if (::myScene.isInitialized) myScene.stop()
         startLoading()
         isInitialized.set(false)
+    }
+
+    fun toggleCropTextures() {
+        isCroppingTextures = !isCroppingTextures
     }
 
     fun toggleAxes() {

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjPreviewEditor.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/ObjPreviewEditor.kt
@@ -43,6 +43,12 @@ class ObjPreviewEditor(
             myComponent.shadingMethod = value
         }
 
+    var isCroppingTextures: Boolean
+        get() = myComponent.isCroppingTextures
+        set(value) {
+            myComponent.isCroppingTextures = value
+        }
+
     var upVector: UpVector
         get() = myComponent.upVector
         set(value) {
@@ -72,6 +78,11 @@ class ObjPreviewEditor(
                     shadingMethod = newPreviewSettings?.defaultShadingMethod ?: ShadingMethod.DEFAULT
                 }
 
+                if (isCroppingTextures == oldPreviewSettings?.cropTextures) {
+                    isCroppingTextures = newPreviewSettings?.cropTextures
+                        ?: ObjPreviewSettingsState.DEFAULT_CROP_TEXTURES
+                }
+
                 if (upVector === oldPreviewSettings?.defaultUpVector) {
                     upVector = newPreviewSettings?.defaultUpVector ?: UpVector.DEFAULT
                 }
@@ -99,6 +110,7 @@ class ObjPreviewEditor(
         val settings = WavefrontObjSettingsState.getInstance()?.objPreviewSettings
 
         shadingMethod = settings?.defaultShadingMethod ?: ShadingMethod.DEFAULT
+        isCroppingTextures = settings?.cropTextures ?: ObjPreviewSettingsState.DEFAULT_CROP_TEXTURES
         upVector = settings?.defaultUpVector ?: UpVector.DEFAULT
         isShowingAxes = settings?.showAxes ?: ObjPreviewSettingsState.DEFAULT_SHOW_AXES
         isShowingGrid = settings?.showGrid ?: ObjPreviewSettingsState.DEFAULT_SHOW_GRID
@@ -128,6 +140,10 @@ class ObjPreviewEditor(
 
     override fun dispose() {
         Disposer.dispose(myComponent)
+    }
+
+    fun toggleCropTextures() {
+        myComponent.toggleCropTextures()
     }
 
     fun toggleAxes() {

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/actions/ToggleCropTexturesAction.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/actions/ToggleCropTexturesAction.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-2021 Slawomir Czerwinski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.czerwinski.intellij.wavefront.editor.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Toggleable
+import com.intellij.openapi.project.DumbAware
+import it.czerwinski.intellij.wavefront.editor.model.ShadingMethod
+
+class ToggleCropTexturesAction : ObjPreviewFileEditorAction(), DumbAware, Toggleable {
+
+    override fun update(event: AnActionEvent) {
+        val editor = findObjPreviewFileEditor(event)
+
+        event.presentation.isEnabled = editor?.shadingMethod === ShadingMethod.MATERIAL
+
+        if (editor != null) {
+            Toggleable.setSelected(event.presentation, editor.isCroppingTextures)
+        }
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val editor = findObjPreviewFileEditor(event)
+
+        if (editor != null) {
+            Toggleable.setSelected(event.presentation, !Toggleable.isSelected(event.presentation))
+            editor.toggleCropTextures()
+        }
+    }
+}

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/ObjPreviewScene.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/ObjPreviewScene.kt
@@ -65,6 +65,7 @@ class ObjPreviewScene(
                 material?.specularColorMap?.let(::prepareTexture)
                 material?.specularExponentMap?.let(::prepareTexture)
                 material?.bumpMap?.let(::prepareTexture)
+                material?.displacementMap?.let(::prepareTexture)
             }
             requestRender()
         }
@@ -83,6 +84,12 @@ class ObjPreviewScene(
         set(value) {
             field = value
             modelChanged.set(true)
+            requestRender()
+        }
+
+    var cropTextures: Boolean = false
+        set(value) {
+            field = value
             requestRender()
         }
 
@@ -224,7 +231,11 @@ class ObjPreviewScene(
                 specularExponentBase = material?.specularExponentBase ?: 0f,
                 specularExponentGain = material?.specularExponentGain ?: 1f,
                 normalmapTexture = material?.bumpMap?.getTexture(gl) ?: fallbackNormalmap,
-                normalmapMultiplier = material?.bumpMapMultiplier ?: 1f
+                normalmapMultiplier = material?.bumpMapMultiplier ?: 1f,
+                displacementTexture = material?.displacementMap?.getTexture(gl) ?: fallbackTexture,
+                displacementGain = material?.displacementGain ?: 1f,
+                displacementQuality = config.displacementQuality,
+                cropTexture = if (cropTextures) 1 else 0
             ),
             facesMesh
         )

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/shaders/MaterialShader.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/shaders/MaterialShader.kt
@@ -88,4 +88,16 @@ data class MaterialShader(
 
     @Uniform(name = "uBumpMult")
     val normalmapMultiplier: Float,
+
+    @Uniform(name = "uDispTex")
+    val displacementTexture: Texture,
+
+    @Uniform(name = "uDispGain")
+    val displacementGain: Float,
+
+    @Uniform(name = "uDispQuality")
+    val displacementQuality: Float,
+
+    @Uniform(name = "uCropTex")
+    val cropTexture: Int,
 )

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/model/PreviewSceneConfig.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/model/PreviewSceneConfig.kt
@@ -24,6 +24,7 @@ data class PreviewSceneConfig(
     val gridLineWidth: Float = ObjPreviewSettingsState.DEFAULT_GRID_LINE_WIDTH,
     val lineWidth: Float = ObjPreviewSettingsState.DEFAULT_LINE_WIDTH,
     val pointSize: Float = ObjPreviewSettingsState.DEFAULT_POINT_SIZE,
+    val displacementQuality: Float = ObjPreviewSettingsState.DEFAULT_DISPLACEMENT_QUALITY
 ) {
     companion object {
         fun fromObjPreviewSettingsState(settings: ObjPreviewSettingsState): PreviewSceneConfig =
@@ -32,7 +33,8 @@ data class PreviewSceneConfig(
                 settings.showFineGrid,
                 settings.gridLineWidth,
                 settings.lineWidth,
-                settings.pointSize
+                settings.pointSize,
+                settings.displacementQuality
             )
     }
 }

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/MtlMaterialElement.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/MtlMaterialElement.kt
@@ -41,6 +41,7 @@ interface MtlMaterialElement : PsiElement {
     val specularExponentGain: Float?
     val dissolveMap: VirtualFile?
     val displacementMap: VirtualFile?
+    val displacementGain: Float?
     val stencilDecalMap: VirtualFile?
     val bumpMap: VirtualFile?
     val bumpMapMultiplier: Float?

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/impl/MtlMaterialElementImpl.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/impl/MtlMaterialElementImpl.kt
@@ -62,6 +62,9 @@ abstract class MtlMaterialElementImpl(
         get() = material?.dissolveMapList?.firstOrNull()?.textureVirtualFile
     override val displacementMap: VirtualFile?
         get() = material?.displacementMapList?.firstOrNull()?.textureVirtualFile
+    override val displacementGain: Float?
+        get() = material?.displacementMapList?.firstOrNull()?.valueModifierOptionList
+            ?.firstOrNull()?.values?.getOrNull(1)
     override val stencilDecalMap: VirtualFile?
         get() = material?.stencilDecalMapList?.firstOrNull()?.textureVirtualFile
     override val bumpMap: VirtualFile?

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/settings/ObjPreviewSettingsState.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/settings/ObjPreviewSettingsState.kt
@@ -30,6 +30,8 @@ data class ObjPreviewSettingsState(
     @field:Attribute var gridLineWidth: Float = DEFAULT_GRID_LINE_WIDTH,
     @field:Attribute var lineWidth: Float = DEFAULT_LINE_WIDTH,
     @field:Attribute var pointSize: Float = DEFAULT_POINT_SIZE,
+    @field:Attribute var cropTextures: Boolean = DEFAULT_CROP_TEXTURES,
+    @field:Attribute var displacementQuality: Float = DEFAULT_DISPLACEMENT_QUALITY,
 ) {
 
     companion object {
@@ -42,6 +44,8 @@ data class ObjPreviewSettingsState(
         const val DEFAULT_GRID_LINE_WIDTH = 1f
         const val DEFAULT_LINE_WIDTH = 1f
         const val DEFAULT_POINT_SIZE = 3f
+        const val DEFAULT_CROP_TEXTURES = false
+        const val DEFAULT_DISPLACEMENT_QUALITY = 7.5f
     }
 
     interface Holder {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -170,6 +170,11 @@
                     icon="WavefrontObjIcons.MATERIAL_SHADING_ACTION"/>
             <separator/>
             <action
+                    id="it.czerwinski.intellij.wavefront.editor.actions.ToggleCropTexturesAction"
+                    class="it.czerwinski.intellij.wavefront.editor.actions.ToggleCropTexturesAction"
+                    icon="WavefrontObjIcons.TOGGLE_CROP_TEXTURES_ACTION"/>
+            <separator/>
+            <action
                     id="it.czerwinski.intellij.wavefront.editor.actions.XUpVectorAction"
                     class="it.czerwinski.intellij.wavefront.editor.actions.XUpVectorAction"
                     icon="WavefrontObjIcons.X_UP_ACTION"/>

--- a/src/main/resources/icons/editor_actions/cropTextures.svg
+++ b/src/main/resources/icons/editor_actions/cropTextures.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16">
+    <path style="fill:#6e6e6e;stroke:none;" d="m 2,2 v -2 h 1 v 2 h 10 a 1,1 0 0 1 1,1 v 10 h 2 v 1 h -2 v 2 h -1 v -2 h -10 a 1,1 0 0 1 -1,-1 v -10 h -2 v -1 h 2 z m 1,1 v 10 h 10 v -10 h -10 "/>
+    <path style="fill:#6e6e6e;stroke:none;" d="m 3.5,3.5 3,0 0,3 -3,0 0,-3 z m 6,0 3,0 0,3 -3,0 0,-3 z m -3,3 3,0 0,3 -3,0 0,-3 z m -3,3 3,0 0,3 -3,0 0,-3 z m 6,0 3,0 0,3 -3,0 0,-3 z"/>
+</svg>

--- a/src/main/resources/icons/editor_actions/cropTextures_dark.svg
+++ b/src/main/resources/icons/editor_actions/cropTextures_dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16">
+    <path style="fill:#afb1b3;stroke:none;" d="m 2,2 v -2 h 1 v 2 h 10 a 1,1 0 0 1 1,1 v 10 h 2 v 1 h -2 v 2 h -1 v -2 h -10 a 1,1 0 0 1 -1,-1 v -10 h -2 v -1 h 2 z m 1,1 v 10 h 10 v -10 h -10 "/>
+    <path style="fill:#afb1b3;stroke:none;" d="m 3.5,3.5 3,0 0,3 -3,0 0,-3 z m 6,0 3,0 0,3 -3,0 0,-3 z m -3,3 3,0 0,3 -3,0 0,-3 z m -3,3 3,0 0,3 -3,0 0,-3 z m 6,0 3,0 0,3 -3,0 0,-3 z"/>
+</svg>

--- a/src/main/resources/messages/WavefrontObjBundle.properties
+++ b/src/main/resources/messages/WavefrontObjBundle.properties
@@ -217,6 +217,8 @@ action.it.czerwinski.intellij.wavefront.editor.actions.SolidShadingMethodAction.
 action.it.czerwinski.intellij.wavefront.editor.actions.SolidShadingMethodAction.description=Sets preview shading method to solid
 action.it.czerwinski.intellij.wavefront.editor.actions.MaterialShadingMethodAction.text=Material Shading
 action.it.czerwinski.intellij.wavefront.editor.actions.MaterialShadingMethodAction.description=Sets preview shading method to material
+action.it.czerwinski.intellij.wavefront.editor.actions.ToggleCropTexturesAction.text=Crop Textures
+action.it.czerwinski.intellij.wavefront.editor.actions.ToggleCropTexturesAction.description=Toggles textures cropping in preview
 action.it.czerwinski.intellij.wavefront.editor.actions.XUpVectorAction.text=X Up
 action.it.czerwinski.intellij.wavefront.editor.actions.XUpVectorAction.description=Sets X unit vector pointing up
 action.it.czerwinski.intellij.wavefront.editor.actions.YUpVectorAction.text=Y Up
@@ -273,6 +275,11 @@ settings.editor.fileTypes.obj.preview.lineWidth.error=Incorrect object line widt
 settings.editor.fileTypes.obj.preview.pointSize=Object point size:
 settings.editor.fileTypes.obj.preview.pointSize.error=Incorrect object point size: “{0}”. Should be a positive number.
 settings.editor.fileTypes.obj.preview.lineWidth.contextHelp=Only line width 1 is guaranteed to be supported. Others depend on the OpenGL implementation.
+settings.editor.fileTypes.obj.preview.rendering=Rendering:
+settings.editor.fileTypes.obj.preview.displacementQuality=Displacement quality:
+settings.editor.fileTypes.obj.preview.displacementQuality.lowest=Lowest
+settings.editor.fileTypes.obj.preview.displacementQuality.highest=Highest
+settings.editor.fileTypes.obj.preview.cropTextures=Crop textures by default
 
 # ObjColorSettingsPage:
 settings.fileTypes.obj.name=Wavefront OBJ

--- a/src/main/resources/shaders/material_fragment_shader.glsl
+++ b/src/main/resources/shaders/material_fragment_shader.glsl
@@ -15,28 +15,65 @@ uniform float uSpecExpBase;
 uniform float uSpecExpGain;
 uniform sampler2D uNormalTex;
 uniform float uBumpMult;
+uniform sampler2D uDispTex;
+uniform float uDispGain;
+uniform float uDispQuality;
+uniform int uCropTex;
 
 varying vec3 vPosTan;
 varying vec3 vCameraPosTan;
 varying vec3 vLightPosTan;
 varying vec2 vTexCoord;
 
+float displacement(vec2 texCoord) {
+    return 1.0 - texture2D(uDispTex, texCoord).r;
+}
+
+vec2 displacedTexCoord(vec3 cameraDir) {
+    float depthStep = pow(2.0, -uDispQuality) * max(dot(vec3(0.0, 0.0, 1.0), cameraDir), 0.01);
+    vec2 texCoordDisplacementStep = cameraDir.xy * uDispGain * depthStep;
+
+    vec2 newTexCoord = vTexCoord;
+    vec2 oldTexCoord = vTexCoord;
+    float newError = displacement(vTexCoord);
+    float oldError = newError;
+
+    for (float depth = 0.0; newError > 0.0; depth += depthStep) {
+        oldTexCoord = newTexCoord;
+        newTexCoord -= texCoordDisplacementStep;
+        oldError = newError;
+        newError = displacement(newTexCoord) - depth;
+    }
+
+    if (newError == oldError) {
+        return oldTexCoord;
+    }
+    return mix(newTexCoord, oldTexCoord, newError / (newError - oldError));
+}
+
 void main() {
     vec3 cameraDir = normalize(vCameraPosTan - vPosTan);
+
+    vec2 texCoord = displacedTexCoord(cameraDir);
+
+    if (uCropTex == 1 && (texCoord.x < 0.0 || texCoord.y < 0.0 || texCoord.x > 1.0 || texCoord.y > 1.0)) {
+        discard;
+    }
+
     vec3 lightDir = normalize(vLightPosTan - vPosTan);
     vec3 halfVector = normalize(lightDir + cameraDir);
 
-    vec3 normal = normalize(texture2D(uNormalTex, vTexCoord).rgb * 2.0 - 1.0);
+    vec3 normal = normalize(texture2D(uNormalTex, texCoord).rgb * 2.0 - 1.0);
     normal = normalize(vec3(normal.x, normal.y, normal.z / uBumpMult));
 
     float exposure = max(dot(normal, lightDir), 0.0);
 
-    float exponent = (uSpecExpBase + texture2D(uSpecExpTex, vTexCoord).r * uSpecExpGain) * uSpecExp;
+    float exponent = (uSpecExpBase + texture2D(uSpecExpTex, texCoord).r * uSpecExpGain) * uSpecExp;
     float specular = pow(max(dot(normal, halfVector), 0.0), exponent);
 
-    vec3 ambColor = texture2D(uAmbTex, vTexCoord).rgb * uAmbColor * 0.4;
-    vec3 diffColor = texture2D(uDiffTex, vTexCoord).rgb * uDiffColor;
-    vec3 specColor = texture2D(uSpecTex, vTexCoord).rgb * uSpecColor;
+    vec3 ambColor = texture2D(uAmbTex, texCoord).rgb * uAmbColor * 0.4;
+    vec3 diffColor = texture2D(uDiffTex, texCoord).rgb * uDiffColor;
+    vec3 specColor = texture2D(uSpecTex, texCoord).rgb * uSpecColor;
     vec3 color = diffColor * exposure + ambColor * (1.0 - exposure) + specColor * specular;
 
     gl_FragColor = vec4(color, 1.0);


### PR DESCRIPTION
Closes #27

Changes:
* Add support for displacement textures in 3D preview
* Add crop textures action in 3D preview
* Add settings for cropping textures and displacement quality
