### PR TITLE
Add support for relative paths to material textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Add support for platform version `252.*`
+- Support for relative paths to material textures
 
 ### Changed
 

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/BaseBufferedImageProvider.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/BaseBufferedImageProvider.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2023 Slawomir Czerwinski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.czerwinski.intellij.wavefront.editor.gl
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import graphics.glimpse.textures.BufferedImageProvider
+import it.czerwinski.intellij.wavefront.actions.gl.BaseMapRenderer
+import it.czerwinski.intellij.wavefront.editor.gl.textures.toBufferedImage
+import it.czerwinski.intellij.wavefront.lang.psi.util.findMatchingTextureVirtualFiles
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
+import kotlin.math.max
+
+abstract class BaseBufferedImageProvider(
+    private val project: Project,
+    private val environmentTextureFilename: String,
+    private val relativeTo: VirtualFile? = null,
+) : BufferedImageProvider {
+
+    override fun createBufferedImage(): BufferedImage? {
+        val inputImage = loadInputImage()
+        val outputHeight = max(inputImage.width / 2, inputImage.height)
+        val outputWidth = outputHeight * 2
+
+        val renderer = createRenderer(inputImage, outputWidth, outputHeight)
+        renderer.render()
+
+        val outputImage = renderer.outputImage?.toBufferedImage(type = BufferedImage.TYPE_INT_RGB)
+        inputImage.flush()
+        if (outputImage != renderer.outputImage) {
+            renderer.outputImage?.flush()
+        }
+        return outputImage
+    }
+
+    private fun loadInputImage(): BufferedImage {
+        val inputFile = checkNotNull(
+            runReadAction {
+                project.findMatchingTextureVirtualFiles(environmentTextureFilename, relativeTo).firstOrNull()
+            }
+        ) {
+            "Could not find texture file: $environmentTextureFilename"
+        }
+        return ImageIO.read(inputFile.inputStream)
+    }
+
+    protected abstract fun createRenderer(
+        inputImage: BufferedImage,
+        outputWidth: Int,
+        outputHeight: Int
+    ): BaseMapRenderer<*>
+}

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/BaseScene.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/BaseScene.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.util.BackgroundTaskUtil
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.jogamp.opengl.GLAnimatorControl
 import com.jogamp.opengl.GLProfile
 import graphics.glimpse.BlendingFactorFunction
@@ -64,8 +65,8 @@ abstract class BaseScene(
     /**
      * Loads texture image from a file with given [filename] before creating a texture.
      */
-    private fun prepareTexture(project: Project, filename: String) {
-        texturesManager.prepare(profile, project, filename)
+    private fun prepareTexture(project: Project, filename: String, relativeTo: VirtualFile? = null) {
+        texturesManager.prepare(profile, project, filename, relativeTo)
     }
 
     /**
@@ -258,6 +259,7 @@ abstract class BaseScene(
     protected inner class FileTextureProvider(
         private val project: Project,
         private val paths: List<String>,
+        private val relativeTo: VirtualFile? = null,
         private val fallbackTexture: () -> Texture
     ) : TextureProvider {
 
@@ -271,7 +273,7 @@ abstract class BaseScene(
             if (isPreparing.compareAndSet(false, true)) {
                 for (path in paths - errors) {
                     try {
-                        prepareTexture(project, path)
+                        prepareTexture(project, filename = path, relativeTo)
                     } catch (expected: Throwable) {
                         errors.add(path)
                         errorLog.addError(

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/DiffuseIrradianceBufferedImageProvider.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/DiffuseIrradianceBufferedImageProvider.kt
@@ -16,41 +16,20 @@
 
 package it.czerwinski.intellij.wavefront.editor.gl
 
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
-import graphics.glimpse.textures.BufferedImageProvider
+import com.intellij.openapi.vfs.VirtualFile
+import it.czerwinski.intellij.wavefront.actions.gl.BaseMapRenderer
 import it.czerwinski.intellij.wavefront.actions.gl.DiffuseIrradianceRenderer
-import it.czerwinski.intellij.wavefront.editor.gl.textures.toBufferedImage
-import it.czerwinski.intellij.wavefront.lang.psi.util.findMatchingTextureVirtualFiles
 import java.awt.image.BufferedImage
-import javax.imageio.ImageIO
-import kotlin.math.max
 
 class DiffuseIrradianceBufferedImageProvider(
-    private val project: Project,
-    private val environmentTextureFilename: String
-) : BufferedImageProvider {
+    project: Project,
+    environmentTextureFilename: String,
+    relativeTo: VirtualFile? = null
+) : BaseBufferedImageProvider(project, environmentTextureFilename, relativeTo) {
 
-    override fun createBufferedImage(): BufferedImage? {
-        val inputFile = checkNotNull(
-            runReadAction { project.findMatchingTextureVirtualFiles(environmentTextureFilename).firstOrNull() }
-        ) {
-            "Could not find texture file: $environmentTextureFilename"
-        }
-        val inputImage = ImageIO.read(inputFile.inputStream)
-        val outputHeight = max(inputImage.width / 2, inputImage.height)
-        val outputWidth = outputHeight * 2
-
-        val renderer = DiffuseIrradianceRenderer(inputImage, SAMPLES, outputWidth, outputHeight)
-        renderer.render()
-
-        val outputImage = renderer.outputImage?.toBufferedImage(type = BufferedImage.TYPE_INT_RGB)
-        inputImage.flush()
-        if (outputImage != renderer.outputImage) {
-            renderer.outputImage?.flush()
-        }
-        return outputImage
-    }
+    override fun createRenderer(inputImage: BufferedImage, outputWidth: Int, outputHeight: Int): BaseMapRenderer<*> =
+        DiffuseIrradianceRenderer(inputImage, SAMPLES, outputWidth, outputHeight)
 
     companion object {
         private const val SAMPLES = 100

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/PreviewScene.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/PreviewScene.kt
@@ -431,46 +431,55 @@ abstract class PreviewScene(
             ambientTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.ambientColorMap, material.diffuseColorMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             diffuseTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.diffuseColorMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             specularTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.specularColorMap, material.metalnessMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             emissionTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.emissionColorMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             specularExponentTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.specularExponentMap, material.roughnessMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             roughnessTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.roughnessMap, material.specularExponentMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             metalnessTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.metalnessMap, material.specularColorMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             normalmapTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.normalMap, material.bumpMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackNormalmap }
             ),
             displacementTextureProvider = FileTextureProvider(
                 project = material.project,
                 paths = listOfNotNull(material.displacementMap),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { fallbackTexture }
             ),
             environmentTextureProvider = FileTextureProvider(
@@ -478,6 +487,7 @@ abstract class PreviewScene(
                 paths = listOfNotNull(
                     material.reflectionMap?.takeIf { material.reflectionMapType == MtlReflectionType.SPHERE }
                 ),
+                relativeTo = material.containingFile?.virtualFile,
                 fallbackTexture = { environmentTexture }
             ),
             irradianceTextureProvider = listOfNotNull(
@@ -485,7 +495,11 @@ abstract class PreviewScene(
             ).firstOrNull()?.let { filename ->
                 GeneratedTextureProvider(
                     key = "$filename\$irradiance",
-                    bufferedImageProvider = DiffuseIrradianceBufferedImageProvider(material.project, filename),
+                    bufferedImageProvider = DiffuseIrradianceBufferedImageProvider(
+                        project = material.project,
+                        environmentTextureFilename = filename,
+                        relativeTo = material.containingFile?.virtualFile
+                    ),
                     fallbackTexture = { irradianceTexture }
                 )
             } ?: FallbackTextureProvider { irradianceTexture },
@@ -498,6 +512,7 @@ abstract class PreviewScene(
                         bufferedImageProvider = PreFilteredEnvironmentBufferedImageProvider(
                             project = material.project,
                             environmentTextureFilename = filename,
+                            relativeTo = material.containingFile?.virtualFile,
                             roughness = index.toFloat() / (TextureResources.REFLECTION_LEVELS_COUNT - 1).toFloat()
                         ),
                         fallbackTexture = { reflectionTextureLevels[index] }

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/textures/TexturesManager.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/editor/gl/textures/TexturesManager.kt
@@ -18,6 +18,7 @@ package it.czerwinski.intellij.wavefront.editor.gl.textures
 
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.jogamp.opengl.GLProfile
 import graphics.glimpse.GlimpseAdapter
 import graphics.glimpse.textures.BufferedImageProvider
@@ -43,9 +44,11 @@ class TexturesManager {
      *
      * This method can be executed without GL thread.
      */
-    fun prepare(profile: GLProfile, project: Project, filename: String) {
+    fun prepare(profile: GLProfile, project: Project, filename: String, relativeTo: VirtualFile? = null) {
         prepare(profile = profile, key = filename) bufferedImageProvider@{
-            val file = checkNotNull(runReadAction { project.findMatchingTextureVirtualFiles(filename).firstOrNull() }) {
+            val file = checkNotNull(
+                value = runReadAction { project.findMatchingTextureVirtualFiles(filename, relativeTo).firstOrNull() }
+            ) {
                 "Could not find texture file: $filename"
             }
             return@bufferedImageProvider ImageIO.read(file.inputStream)

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/TextureFileReference.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/TextureFileReference.kt
@@ -47,7 +47,7 @@ class TextureFileReference(
             .toTypedArray()
 
     private fun findMatchingMtlFiles(): List<PsiFile> =
-        myElement.project.findMatchingTextureFiles(filename)
+        myElement.project.findMatchingTextureFiles(filename, relativeTo = element.containingFile?.virtualFile)
 
     override fun resolve(): PsiElement? =
         findMatchingMtlFiles().singleOrNull()

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/impl/MtlTextureElementImpl.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/impl/MtlTextureElementImpl.kt
@@ -37,7 +37,9 @@ abstract class MtlTextureElementImpl(
         get() = textureFilenameNode?.text
 
     override val textureFiles: Collection<PsiFile>
-        get() = textureFilename?.let { filename -> project.findMatchingTextureFiles(filename) }.orEmpty()
+        get() = textureFilename
+            ?.let { filename -> project.findMatchingTextureFiles(filename, relativeTo = containingFile.virtualFile) }
+            .orEmpty()
 
     override val valueModifierOptionElement: MtlValueModifierOption?
         get() = valueModifierOptionList.firstOrNull()

--- a/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/util/TextureFiles.kt
+++ b/src/main/kotlin/it/czerwinski/intellij/wavefront/lang/psi/util/TextureFiles.kt
@@ -18,12 +18,14 @@ package it.czerwinski.intellij.wavefront.lang.psi.util
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.jogamp.opengl.util.texture.TextureIO
+import java.io.File
 
 private val textureFilesExtensions = listOf(
     TextureIO.DDS,
@@ -45,12 +47,22 @@ fun Project.findAllTextureFiles(): List<PsiFile> =
         PsiManager.getInstance(this).findFile(virtualFile)
     }
 
-fun Project.findMatchingTextureFiles(filename: String): List<PsiFile> =
-    findMatchingTextureVirtualFiles(filename)
+fun Project.findMatchingTextureFiles(filename: String, relativeTo: VirtualFile? = null): List<PsiFile> =
+    findMatchingTextureVirtualFiles(filename, relativeTo)
         .mapNotNull { virtualFile -> PsiManager.getInstance(this).findFile(virtualFile) }
 
-fun Project.findMatchingTextureVirtualFiles(filename: String): Collection<VirtualFile> =
-    FilenameIndex.getVirtualFilesByName(filename, GlobalSearchScope.allScope(this))
+fun Project.findMatchingTextureVirtualFiles(
+    filename: String,
+    relativeTo: VirtualFile? = null
+): Collection<VirtualFile> {
+    val baseDirectory = if (relativeTo?.isDirectory != false) relativeTo else relativeTo.parent
+    val relativeFile = baseDirectory?.findFile(relativePath = filename)
+    if (relativeFile != null) {
+        return listOf(relativeFile)
+    }
+    val rawFilename = File(filename).name
+    return FilenameIndex.getVirtualFilesByName(rawFilename, GlobalSearchScope.allScope(this))
+}
 
 fun PsiElement?.isTextureFile(): Boolean =
     this is PsiFile && textureFilesExtensions.any { ext -> this.name.endsWith(".$ext", ignoreCase = true) }


### PR DESCRIPTION
Closes #653

Changes:
* Add support for relative paths to material textures
* Refactor `BufferedImageProvider`s
